### PR TITLE
Added intellij IDE files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@
 
 # Mac filesystem dust
 /.DS_Store
+
+# IDEA Specific
+/.idea
+*.iml


### PR DESCRIPTION
* In this PR. I copied over .gitignore lines relating to Intellij IDE, directly from the .gitignore file in the"Towny" repo.
* This will allow developers working with Intellij to use the dynmap repo more easily.

TESTING
- Before making this change, GIT was prompting to add some intellij files.
- After making this change, GIT was not prompting for any extra files