### PR TITLE
Proposed 0.75

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,22 @@ Also, the display of the town outlines can be restricted to a minimum zoom-in le
 Note: If you are currently using the region component for Towny in Dynmap, you should disable that support
 
 ## Supported Versions
+As of 0.75, Dynmap-Towny has the following minimum requirements:
 
--   Dynmap v1.7.1 or later 
--   Towny Advanced 0.94.0.2 or later
+-   CraftBukkit / Spigot / Paper 1.14.4 _OR_ 1.15.2
+-   Dynmap 2.5 or later 
+-   TownyAdvanced 0.95.2.10 or later
+-   TownyChat 0.65 or later (_Optional_)
 
 ## Plugin Configuration
 After the first load, there will be a config.yml file in the plugins/Dynmap-Towny directory. Details of the default configuration, and all the provided settings, can be found [here](https://github.com/hankjordan/Dynmap-Towny/wiki)
 
 ## Building from source
-Place Towny-0.94.0.4.jar, TownyChat-0.55.jar and bukkit.jar a folder named deps in the root directory. Compile using maven. Requires Java 8.
+Building presently requires manual download of TownyChat, as it does not have a Maven repository (yet).
+
+1. Create a 'deps' folder in the project's root directory.
+2. Download and place TownyChat-0.65.jar into the 'deps' folder.
+3. Compile using Maven. (_Requires a Java JDK for Java 8+_)
 
 ## Acknowledgements
 This is a fork of [Dynmap-Towny](https://github.com/webbukkit/Dynmap-Towny).

--- a/pom.xml
+++ b/pom.xml
@@ -1,84 +1,83 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>org.dynmap</groupId>
-  <artifactId>Dynmap-Towny</artifactId>
-  <version>0.74</version>
-  
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.dynmap</groupId>
+    <artifactId>Dynmap-Towny</artifactId>
+    <version>0.75</version>
+
     <build>
-  	  <resources>
-		<resource>
-		  <directory>src/main/resources</directory>
-		  <filtering>true</filtering>
-		  <includes>
-			<include>*.yml</include>
-			<include>*.txt</include>
-		  </includes>
-		</resource>
-		<resource>
-		  <directory>src/main/resources</directory>
-		  <filtering>false</filtering>
-		  <excludes>
-			<exclude>*.yml</exclude>
-			<exclude>*.txt</exclude>
-		  </excludes>
-		</resource>
-	  </resources>
-  
-  	<plugins>
- 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.0.2</version>
-				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
-				</configuration>
-			</plugin>
-  	</plugins>
-  </build>
-     <repositories>
-		<repository>
-			<releases>
-			</releases>
-			<snapshots>
-			</snapshots>
-			<id>dynmap-repo</id>
-			<url>http://repo.mikeprimm.com/</url>
-		</repository>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>*.yml</include>
+                    <include>*.txt</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>false</filtering>
+                <excludes>
+                    <exclude>*.yml</exclude>
+                    <exclude>*.txt</exclude>
+                </excludes>
+            </resource>
+        </resources>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.0.2</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <repositories>
         <repository>
             <id>github-Towny</id>
-            <url>https://maven.pkg.github.com/TownyAdvanced/Towny/packages/</url>
-        </repository> 
-	</repositories>
-  
-  <dependencies>
-  	<dependency>
-  		<groupId>us.dynmap</groupId>
-  		<artifactId>dynmap-api</artifactId>
-  		<version>2.2</version>
-  	</dependency>
-    <dependency>
+            <url>https://maven.pkg.github.com/TownyAdvanced/Towny/</url>
+        </repository>
+        <repository>
+            <id>spigot-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+        </repository>
+        <repository>
+            <id>dynmap-repo</id>
+            <url>http://repo.mikeprimm.com/</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
             <version>1.14.4-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>us.dynmap</groupId>
+            <artifactId>dynmap-api</artifactId>
+            <version>2.5</version>
+        </dependency>
+        <dependency>
+            <groupId>com.palmergames.bukkit.towny</groupId>
+            <artifactId>Towny</artifactId>
+            <version>0.95.2.10</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.palmergames</groupId>
+            <artifactId>TownyChat</artifactId>
+            <version>0.65</version>
             <scope>system</scope>
-            <systemPath>${project.basedir}/deps/bukkit.jar</systemPath>
-    </dependency>
-  	<dependency>
-      <groupId>com.palmergames.bukkit.towny</groupId>
-      <artifactId>Towny</artifactId>
-      <version>0.95.0.5</version>
-      <scope>provided</scope>
-  	</dependency>
-  	<dependency>
-  		<groupId>com.palmergames</groupId>
-  		<artifactId>TownyChat</artifactId>
-  		<version>0.55</version>
-  		<scope>system</scope>
-  		<systemPath>${project.basedir}/deps/TownyChat-0.55.jar</systemPath>
-  	</dependency>
-  </dependencies>
-  <properties>
-  	<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  </properties>
+            <systemPath>${project.basedir}/deps/TownyChat-0.65.jar</systemPath>
+        </dependency>
+    </dependencies>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
 </project>

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,7 +2,7 @@ name: Dynmap-Towny
 main: org.dynmap.towny.DynmapTownyPlugin
 version: "${project.version}"
 author: LlmDl
-api-version: 1.13
+api-version: 1.14
 depend: [ dynmap, Towny ]
 softdepend: [ TownyChat ]
 


### PR DESCRIPTION
- Updates Dynmap-Towny to version 0.75
- Plugin.yml Update: 
  - Update api-version to 1.14 (Dropping 1.13 support, retain 1.14 compat)
- README Update:
  - Redone 'Supported Versions' and 'Building from Source'
- POM Update:
  - "Fixed" POM model from using tabs to using 4 spaces. POM originally had manual spaces (2-spaced; IDE automated, I'm too lazy to revert this...)
  - Added repository for Bukkit's API (spigot-repo)
  - Fixed GitHub Packages repository link for github-Towny (Build was failing)
  - Updated Dependencies
    - Towny to 0.95.2.10 (from 0.95.0.5)
    - TownyChat to 0.65 (from 0.55)
    - DynmapAPI to 2.5 (from 2.2)
      - Maven for it is out of date, API should technically be on 3.0-SNAPSHOT
      - Dynmap hasn't kept it up to date after switching to Gradle
