### PR TITLE
Dynamic Nation Colours 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 /.settings
 /.vscode
 
+# Intellij
+.idea
+
 #dependencies
 /deps
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # Intellij
 .idea
+*.iml
 
 #dependencies
 /deps

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>com.palmergames.bukkit.towny</groupId>
             <artifactId>Towny</artifactId>
-            <version>0.96.1.0</version>
+            <version>0.96.1.3</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -68,15 +68,15 @@
             <groupId>com.palmergames.bukkit.towny</groupId>
             <artifactId>Towny</artifactId>
             <version>0.96.1.0</version>
-            <scope>provided</scope>
+            <scope>system</scope>
             <systemPath>${project.basedir}/deps/Towny-0.96.1.0.jar</systemPath>
         </dependency>
         <dependency>
             <groupId>com.palmergames</groupId>
             <artifactId>TownyChat</artifactId>
-            <version>0.69</version>
+            <version>0.68</version>
             <scope>system</scope>
-            <systemPath>${project.basedir}/deps/TownyChat-0.69.jar</systemPath>
+            <systemPath>${project.basedir}/deps/TownyChat-0.68.jar</systemPath>
         </dependency>
     </dependencies>
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -55,8 +55,9 @@
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
-            <version>1.14.4-R0.1-SNAPSHOT</version>
-            <scope>provided</scope>
+            <version>1.13.2</version>
+            <scope>system</scope>
+            <systemPath>${project.basedir}/deps/bukkit-1.13.2.jar</systemPath>
         </dependency>
         <dependency>
             <groupId>us.dynmap</groupId>
@@ -66,8 +67,9 @@
         <dependency>
             <groupId>com.palmergames.bukkit.towny</groupId>
             <artifactId>Towny</artifactId>
-            <version>0.95.2.10</version>
-            <scope>provided</scope>
+            <version>0.95.2.15</version>
+            <scope>system</scope>
+            <systemPath>${project.basedir}/deps/Towny-0.95.2.15.jar</systemPath>
         </dependency>
         <dependency>
             <groupId>com.palmergames</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -55,9 +55,8 @@
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
-            <version>1.13.2</version>
-            <scope>system</scope>
-            <systemPath>${project.basedir}/deps/bukkit-1.13.2.jar</systemPath>
+            <version>1.14.4-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>us.dynmap</groupId>
@@ -68,15 +67,14 @@
             <groupId>com.palmergames.bukkit.towny</groupId>
             <artifactId>Towny</artifactId>
             <version>0.96.1.0</version>
-            <scope>system</scope>
-            <systemPath>${project.basedir}/deps/Towny-0.96.1.0.jar</systemPath>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.palmergames</groupId>
             <artifactId>TownyChat</artifactId>
-            <version>0.68</version>
+            <version>0.69</version>
             <scope>system</scope>
-            <systemPath>${project.basedir}/deps/TownyChat-0.68.jar</systemPath>
+            <systemPath>${project.basedir}/deps/TownyChat-0.69.jar</systemPath>
         </dependency>
     </dependencies>
     <properties>

--- a/src/main/java/org/dynmap/towny/DynmapTownyPlugin.java
+++ b/src/main/java/org/dynmap/towny/DynmapTownyPlugin.java
@@ -486,7 +486,7 @@ public class DynmapTownyPlugin extends JavaPlugin {
 
                 if(nationBoard.contains("mapcolor-")) {
                     String[] styleValues = nationBoard.split("mapcolor-")[1].split(",");
-                    int nationColor =  Integer.parseInt(styleValues[0].trim());
+                    int nationColor =  Integer.parseInt(styleValues[0].trim(), 16);
 
                     //Set stroke style
                     double strokeOpacity = m.getLineOpacity();

--- a/src/main/java/org/dynmap/towny/DynmapTownyPlugin.java
+++ b/src/main/java/org/dynmap/towny/DynmapTownyPlugin.java
@@ -482,10 +482,10 @@ public class DynmapTownyPlugin extends JavaPlugin {
         try {
             if(town.hasNation()) {
                 Nation nation = town.getNation();
-                String nationBoard = nation.getNationBoard();
+                String nationBoardLowerCase = nation.getNationBoard().toLowerCase();
 
-                if(nationBoard.toLowerCase().contains("mapcolor-")) {
-                    String colorAsString = nationBoard.toLowerCase().split("mapcolor-")[1].split("-")[0].trim();
+                if(nationBoardLowerCase.contains("mapcolor-")) {
+                    String colorAsString = nationBoardLowerCase.split("mapcolor-")[1].split("-")[0].trim();
                     int nationColor =  Integer.parseInt(colorAsString, 16);
 
                     //Set stroke style

--- a/src/main/java/org/dynmap/towny/DynmapTownyPlugin.java
+++ b/src/main/java/org/dynmap/towny/DynmapTownyPlugin.java
@@ -62,6 +62,7 @@ public class DynmapTownyPlugin extends JavaPlugin {
     boolean reload = false;
     private boolean playersbytown;
     private boolean playersbynation;
+    private boolean dynamicNationColorsEnabled;
     
     FileConfiguration cfg;
     MarkerSet set;
@@ -521,14 +522,13 @@ public class DynmapTownyPlugin extends JavaPlugin {
         m.setRangeY(y, y);
         m.setBoostFlag(defstyle.getBoost(as, ns));
 
-        //If the nation, in-game, has chosen some style settings, use those
+        //If dynamic nation colors is enabled, read the color from the nation object
         try {
-            if(town.hasNation()) {
+            if(dynamicNationColorsEnabled && town.hasNation()) {
                 Nation nation = town.getNation();
-                String nationBoardLowerCase = nation.getNationBoard().toLowerCase();
 
-                if(nationBoardLowerCase.contains("mapcolor-")) {
-                    String colorAsString = nationBoardLowerCase.split("mapcolor-")[1].split("-")[0].trim();
+                if(nation.getMapColorHexCode() != null) {
+                    String colorAsString = nation.getMapColorHexCode();
                     int nationColor =  Integer.parseInt(colorAsString, 16);
 
                     //Set stroke style
@@ -544,7 +544,7 @@ public class DynmapTownyPlugin extends JavaPlugin {
         } catch (Exception ex) {}
 
     }
-    
+
     private MarkerIcon getMarkerIcon(Town town) {
         String id = town.getName();
         AreaStyle as = cusstyle.get(id);
@@ -1069,6 +1069,8 @@ public class DynmapTownyPlugin extends JavaPlugin {
                 info("Dynmap does not support function needed for 'visibility-by-nation' - need to upgrade to 0.60 or later");
             }
         }
+
+        dynamicNationColorsEnabled = cfg.getBoolean("dynamic-nation-colors", true);
 
         /* Set up update job - based on periond */
         int per = cfg.getInt("update.period", 300);

--- a/src/main/java/org/dynmap/towny/DynmapTownyPlugin.java
+++ b/src/main/java/org/dynmap/towny/DynmapTownyPlugin.java
@@ -485,8 +485,8 @@ public class DynmapTownyPlugin extends JavaPlugin {
                 String nationBoard = nation.getNationBoard();
 
                 if(nationBoard.contains("mapcolor-")) {
-                    String[] styleValues = nationBoard.split("mapcolor-")[1].split(",");
-                    int nationColor =  Integer.parseInt(styleValues[0].trim(), 16);
+                    String colorAsString = nationBoard.split("mapcolor-")[1].split("-")[0].trim();
+                    int nationColor =  Integer.parseInt(colorAsString, 16);
 
                     //Set stroke style
                     double strokeOpacity = m.getLineOpacity();

--- a/src/main/java/org/dynmap/towny/DynmapTownyPlugin.java
+++ b/src/main/java/org/dynmap/towny/DynmapTownyPlugin.java
@@ -484,8 +484,8 @@ public class DynmapTownyPlugin extends JavaPlugin {
                 Nation nation = town.getNation();
                 String nationBoard = nation.getNationBoard();
 
-                if(nationBoard.contains("mapcolor-")) {
-                    String colorAsString = nationBoard.split("mapcolor-")[1].split("-")[0].trim();
+                if(nationBoard.toLowerCase().contains("mapcolor-")) {
+                    String colorAsString = nationBoard.toLowerCase().split("mapcolor-")[1].split("-")[0].trim();
                     int nationColor =  Integer.parseInt(colorAsString, 16);
 
                     //Set stroke style

--- a/src/main/java/org/dynmap/towny/DynmapTownyPlugin.java
+++ b/src/main/java/org/dynmap/towny/DynmapTownyPlugin.java
@@ -466,7 +466,7 @@ public class DynmapTownyPlugin extends JavaPlugin {
     private void addStyle(Town town, String resid, String natid, AreaMarker m, TownBlockType btype) {
         AreaStyle as = cusstyle.get(resid);	/* Look up custom style for town, if any */
         AreaStyle ns = nationstyle.get(natid);	/* Look up nation style, if any */
-
+        
         if(btype == null) {
             m.setLineStyle(defstyle.getStrokeWeight(as, ns), defstyle.getStrokeOpacity(as, ns), defstyle.getStrokeColor(as, ns));
         }
@@ -495,7 +495,7 @@ public class DynmapTownyPlugin extends JavaPlugin {
                     String[] styleValues = nationBoard.split("map_fill_style=")[1].split(",");
                     int fillColor =  Integer.parseInt(styleValues[0].trim());
                     double fillOpacity = Double.parseDouble(styleValues[1].trim());
-                    m.setFillStyle(fillColor, fillOpacity);
+                    m.setFillStyle(fillColor, (int)fillOpacity);
                 }
             }
         } catch (Exception ex) {}

--- a/src/main/java/org/dynmap/towny/DynmapTownyPlugin.java
+++ b/src/main/java/org/dynmap/towny/DynmapTownyPlugin.java
@@ -463,10 +463,10 @@ public class DynmapTownyPlugin extends JavaPlugin {
         return true;
     }
         
-    private void addStyle(String resid, String natid, AreaMarker m, TownBlockType btype) {
+    private void addStyle(Town town, String resid, String natid, AreaMarker m, TownBlockType btype) {
         AreaStyle as = cusstyle.get(resid);	/* Look up custom style for town, if any */
         AreaStyle ns = nationstyle.get(natid);	/* Look up nation style, if any */
-        
+
         if(btype == null) {
             m.setLineStyle(defstyle.getStrokeWeight(as, ns), defstyle.getStrokeOpacity(as, ns), defstyle.getStrokeColor(as, ns));
         }
@@ -477,6 +477,29 @@ public class DynmapTownyPlugin extends JavaPlugin {
         double y = defstyle.getY(as, ns);
         m.setRangeY(y, y);
         m.setBoostFlag(defstyle.getBoost(as, ns));
+
+        //If the nation, in-game, has chosen some style settings, use those
+        try {
+            if(town.hasNation()) {
+                Nation nation = town.getNation();
+                String nationBoard = nation.getNationBoard();
+
+                if(nationBoard.contains("map_border_style=")) {
+                    String[] styleValues = nationBoard.split("map_border_style=")[1].split(",");
+                    int strokeColor =  Integer.parseInt(styleValues[0].trim());
+                    double strokeOpacity = Double.parseDouble(styleValues[1].trim());
+                    int strokeWeight = Integer.parseInt(styleValues[2].trim());
+                    m.setLineStyle(strokeColor, strokeOpacity, strokeWeight);
+                }
+                if(nationBoard.contains("map_fill_style=")) {
+                    String[] styleValues = nationBoard.split("map_fill_style=")[1].split(",");
+                    int fillColor =  Integer.parseInt(styleValues[0].trim());
+                    double fillOpacity = Double.parseDouble(styleValues[1].trim());
+                    m.setFillStyle(fillColor, fillOpacity);
+                }
+            }
+        } catch (Exception ex) {}
+
     }
     
     private MarkerIcon getMarkerIcon(Town town) {
@@ -712,7 +735,7 @@ public class DynmapTownyPlugin extends JavaPlugin {
                 	if(town.getNation() != null)
                 		nation = town.getNation().getName();
                 } catch (Exception ex) {}
-                addStyle(town.getName(), nation, m, btype);
+                addStyle(town, town.getName(), nation, m, btype);
 
                 /* Add to map */
                 newmap.put(polyid, m);

--- a/src/main/java/org/dynmap/towny/DynmapTownyPlugin.java
+++ b/src/main/java/org/dynmap/towny/DynmapTownyPlugin.java
@@ -491,11 +491,11 @@ public class DynmapTownyPlugin extends JavaPlugin {
                     //Set stroke style
                     double strokeOpacity = m.getLineOpacity();
                     int strokeWeight = m.getLineWeight();
-                    m.setLineStyle(nationColor, strokeOpacity, strokeWeight);
+                    m.setLineStyle(strokeWeight, strokeOpacity, nationColor);
 
                     //Set fill style
                     double fillOpacity = m.getFillOpacity();
-                    m.setFillStyle(nationColor, (int)fillOpacity);
+                    m.setFillStyle(fillOpacity, nationColor);
                 }
             }
         } catch (Exception ex) {}

--- a/src/main/java/org/dynmap/towny/DynmapTownyPlugin.java
+++ b/src/main/java/org/dynmap/towny/DynmapTownyPlugin.java
@@ -484,18 +484,18 @@ public class DynmapTownyPlugin extends JavaPlugin {
                 Nation nation = town.getNation();
                 String nationBoard = nation.getNationBoard();
 
-                if(nationBoard.contains("map_border_style=")) {
-                    String[] styleValues = nationBoard.split("map_border_style=")[1].split(",");
-                    int strokeColor =  Integer.parseInt(styleValues[0].trim());
-                    double strokeOpacity = Double.parseDouble(styleValues[1].trim());
-                    int strokeWeight = Integer.parseInt(styleValues[2].trim());
-                    m.setLineStyle(strokeColor, strokeOpacity, strokeWeight);
-                }
-                if(nationBoard.contains("map_fill_style=")) {
-                    String[] styleValues = nationBoard.split("map_fill_style=")[1].split(",");
-                    int fillColor =  Integer.parseInt(styleValues[0].trim());
-                    double fillOpacity = Double.parseDouble(styleValues[1].trim());
-                    m.setFillStyle(fillColor, (int)fillOpacity);
+                if(nationBoard.contains("mapcolor-")) {
+                    String[] styleValues = nationBoard.split("mapcolor-")[1].split(",");
+                    int nationColor =  Integer.parseInt(styleValues[0].trim());
+
+                    //Set stroke style
+                    double strokeOpacity = m.getLineOpacity();
+                    int strokeWeight = m.getLineWeight();
+                    m.setLineStyle(nationColor, strokeOpacity, strokeWeight);
+
+                    //Set fill style
+                    double fillOpacity = m.getFillOpacity();
+                    m.setFillStyle(nationColor, (int)fillOpacity);
                 }
             }
         } catch (Exception ex) {}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -26,6 +26,9 @@ visibility-by-town: true
 # Allow all residents of a given nation to see one another, when player info is protected in dynmap
 visibility-by-nation: true
 
+# Use dynamic nation colors, which are set in-game by individual nations (using /n set mapcolor <color>)
+dynamic-nation-colors: true
+
 # Format for popup - substitute values for macros
 infowindow: '<div class="infowindow"><span style="font-size:120%;">%regionname% (%nation%)</span><br /> Mayor <span style="font-weight:bold;">%playerowners%</span><br /> Associates <span style="font-weight:bold;">%playermanagers%</span><br/>Flags<br /><span style="font-weight:bold;">%flags%</span></div>'
 


### PR DESCRIPTION
**SUMMARY**
- This is a feature for dynamic nation colours
- The feature works in combination with new code in the Towny plugin.
  Tha towny code can be reviewed in the "Dynamic nation colours" PR in the Towny repo.

**DESCRIPTION**
- This feature immediately gives colors to all nations on the dynmap when the Towny jar is deployed
- After it does this, it allows the colors to be changed easily, without restarting the dynmap or towny plugins
- An allowed list of colors is found in the Towny plugin config.yml
- Existing nations automatically get a random allowed color when the server is first restarted
- New nations automatically get a random allowed color
- The command to change color is '/n set mapcolor <color>'
- By default kings can change their nation color, but this can be restricted by permission
- Admins can change nation colors using 'ta nation <nation> set mapcolor <color>'
