### PR TITLE
Added optional field for culture as requested by user Violetta

### DIFF
--- a/src/main/java/org/dynmap/towny/DynmapTownyPlugin.java
+++ b/src/main/java/org/dynmap/towny/DynmapTownyPlugin.java
@@ -16,6 +16,7 @@ import java.util.logging.Logger;
 import com.palmergames.bukkit.towny.TownyEconomyHandler;
 import com.palmergames.bukkit.towny.TownyFormatter;
 import com.palmergames.bukkit.towny.TownySettings;
+import com.palmergames.bukkit.towny.object.metadata.StringDataField;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -523,6 +524,12 @@ public class DynmapTownyPlugin extends JavaPlugin {
         flgs += "<br/>fire: " + town.isFire();
         flgs += "<br/>nation: " + nation;
         v = v.replace("%flags%", flgs);
+
+        //Town culture (TownyCultures plugin is needed for this)
+        if(town.hasMeta("townycultures_culture")) {
+            StringDataField cultureStringDataField = (StringDataField)town.getMetadata("townycultures_culture");
+            v = v.replace("%culture%", cultureStringDataField.getValue());
+        }
 
         return v;
     }


### PR DESCRIPTION
#### Description: 
- Added optional field for culture (on the dynmap Town popup), as requested by user Violetta

#### New Nodes/Commands/ConfigOptions: 
- %culture% can be added to the town screen

#### Relevant Issue ticket:
N/A
____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.

