### PR TITLE
Improve town mapcolour retrieval

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>com.github.TownyAdvanced</groupId>
             <artifactId>Towny</artifactId>
-            <version>0.96.6.0</version>
+            <version>0.96.7.8</version>
         </dependency>
         <dependency>
 	        <groupId>com.github.TownyAdvanced</groupId>

--- a/src/main/java/org/dynmap/towny/DynmapTownyPlugin.java
+++ b/src/main/java/org/dynmap/towny/DynmapTownyPlugin.java
@@ -977,7 +977,7 @@ public class DynmapTownyPlugin extends JavaPlugin {
             townychat = (Chat)p;
         }
         
-		if (Version.fromString(towny.getDescription().getVersion()).compareTo(requiredTownyVersion) >= 0) {
+		if (Version.fromString(towny.getDescription().getVersion()).compareTo(requiredTownyVersion) < 0) {
 			getLogger().severe("Towny version does not meet required minimum version: " + requiredTownyVersion.toString());
 			this.getServer().getPluginManager().disablePlugin(this);
 			return;

--- a/src/main/java/org/dynmap/towny/DynmapTownyPlugin.java
+++ b/src/main/java/org/dynmap/towny/DynmapTownyPlugin.java
@@ -557,19 +557,21 @@ public class DynmapTownyPlugin extends JavaPlugin {
 
         //If dynamic nation colors is enabled, read the color from the nation object
         try {
-            if(dynamicNationColorsEnabled && town.hasNation()) {
-                if(town.getMapColorHexCode() != null) {
-                    //Get town map colour
-                    int townMapColor = Integer.parseInt(town.getMapColorHexCode(), 16);
+            if(dynamicNationColorsEnabled) {
+                //Get town map colour (if any)
+                String townMapColorHexCode = town.getMapColorHexCode();
+                if(townMapColorHexCode != null) {
+                    //Get colour as int
+                    int townMapColorInteger = Integer.parseInt(townMapColorHexCode, 16);
 
                     //Set stroke style
                     double strokeOpacity = m.getLineOpacity();
                     int strokeWeight = m.getLineWeight();
-                    m.setLineStyle(strokeWeight, strokeOpacity, townMapColor);
+                    m.setLineStyle(strokeWeight, strokeOpacity, townMapColorInteger);
 
                     //Set fill style
                     double fillOpacity = m.getFillOpacity();
-                    m.setFillStyle(fillOpacity, townMapColor);
+                    m.setFillStyle(fillOpacity, townMapColorInteger);
                 }
             }
         } catch (Exception ex) {}

--- a/src/main/java/org/dynmap/towny/DynmapTownyPlugin.java
+++ b/src/main/java/org/dynmap/towny/DynmapTownyPlugin.java
@@ -54,7 +54,7 @@ import com.palmergames.bukkit.TownyChat.Chat;
 
 public class DynmapTownyPlugin extends JavaPlugin {
 	
-	private static Version requiredTownyVersion = Version.fromString("0.96.6.0");
+	private static Version requiredTownyVersion = Version.fromString("0.96.7.8");
     private static Logger log;
     private static final String DEF_INFOWINDOW = "<div class=\"infowindow\"><span style=\"font-size:120%;\">%regionname% (%nation%)</span><br /> Mayor <span style=\"font-weight:bold;\">%playerowners%</span><br /> Associates <span style=\"font-weight:bold;\">%playermanagers%</span><br/>Flags<br /><span style=\"font-weight:bold;\">%flags%</span></div>";
     private static final String NATION_NONE = "_none_";
@@ -558,20 +558,18 @@ public class DynmapTownyPlugin extends JavaPlugin {
         //If dynamic nation colors is enabled, read the color from the nation object
         try {
             if(dynamicNationColorsEnabled && town.hasNation()) {
-                Nation nation = town.getNation();
-
-                if(nation.getMapColorHexCode() != null) {
-                    String colorAsString = nation.getMapColorHexCode();
-                    int nationColor =  Integer.parseInt(colorAsString, 16);
+                if(town.getMapColorHexCode() != null) {
+                    //Get town map colour
+                    int townMapColor = Integer.parseInt(town.getMapColorHexCode(), 16);
 
                     //Set stroke style
                     double strokeOpacity = m.getLineOpacity();
                     int strokeWeight = m.getLineWeight();
-                    m.setLineStyle(strokeWeight, strokeOpacity, nationColor);
+                    m.setLineStyle(strokeWeight, strokeOpacity, townMapColor);
 
                     //Set fill style
                     double fillOpacity = m.getFillOpacity();
-                    m.setFillStyle(fillOpacity, nationColor);
+                    m.setFillStyle(fillOpacity, townMapColor);
                 }
             }
         } catch (Exception ex) {}


### PR DESCRIPTION
- Current code uses nation.getMapColorHexCode() to get town colours
- However a new method was added recently in 0.96.7.8 - town.getMapColorHexCode().
- This method is hooked up to an event, and is needed for some ahem myserterious work I am doing at the moment in siegewar.
- In this PR I update the code to get the town colour using the new method
- Also fixed an issue where the version checker was not working right

[x] Tested on local server
[x] Usual TownyAdvanced copyright acceptance etc.