### PR TITLE
Added event for building the town popup

### DIFF
--- a/src/main/java/org/dynmap/towny/DynmapTownyPlugin.java
+++ b/src/main/java/org/dynmap/towny/DynmapTownyPlugin.java
@@ -51,6 +51,7 @@ import com.palmergames.bukkit.towny.exceptions.EconomyException;
 import com.palmergames.bukkit.towny.object.TownyWorld;
 import com.palmergames.bukkit.util.Version;
 import com.palmergames.bukkit.TownyChat.Chat;
+import org.dynmap.towny.events.BuildTownMarkerDescriptionEvent;
 
 public class DynmapTownyPlugin extends JavaPlugin {
 	
@@ -803,8 +804,12 @@ public class DynmapTownyPlugin extends JavaPlugin {
                     m.setCornerLocations(x, z); /* Replace corner locations */
                     m.setLabel(name);   /* Update label */
                 }
-                m.setDescription(desc); /* Set popup */
-            
+                {
+                    /* Set popup */
+                    BuildTownMarkerDescriptionEvent event = new BuildTownMarkerDescriptionEvent(town, desc);
+                    Bukkit.getPluginManager().callEvent(event);
+                    m.setDescription(event.getDescription());
+                }
                 /* Set line and fill properties */
                 String nation = NATION_NONE;
                 try {
@@ -844,7 +849,12 @@ public class DynmapTownyPlugin extends JavaPlugin {
                         home.setLabel(name);   /* Update label */
                         home.setMarkerIcon(ico);
                     }
-                    home.setDescription(desc); /* Set popup */
+                    {
+                        /* Set popup */
+                        BuildTownMarkerDescriptionEvent event = new BuildTownMarkerDescriptionEvent(town, desc);
+                        Bukkit.getPluginManager().callEvent(event);
+                        home.setDescription(event.getDescription()); /* Set popup */
+                    }
                     newmark.put(markid, home);
                 }
             }

--- a/src/main/java/org/dynmap/towny/DynmapTownyPlugin.java
+++ b/src/main/java/org/dynmap/towny/DynmapTownyPlugin.java
@@ -853,7 +853,7 @@ public class DynmapTownyPlugin extends JavaPlugin {
                         /* Set popup */
                         BuildTownMarkerDescriptionEvent event = new BuildTownMarkerDescriptionEvent(town, desc);
                         Bukkit.getPluginManager().callEvent(event);
-                        home.setDescription(event.getDescription()); /* Set popup */
+                        home.setDescription(event.getDescription());
                     }
                     newmark.put(markid, home);
                 }

--- a/src/main/java/org/dynmap/towny/DynmapTownyPlugin.java
+++ b/src/main/java/org/dynmap/towny/DynmapTownyPlugin.java
@@ -638,7 +638,9 @@ public class DynmapTownyPlugin extends JavaPlugin {
     	if(blocks.isEmpty())
     	    return;
         /* Build popup */
-        String desc = formatInfoWindow(town, btype);
+        BuildTownMarkerDescriptionEvent event = new BuildTownMarkerDescriptionEvent(town, formatInfoWindow(town, btype));
+        Bukkit.getPluginManager().callEvent(event);
+        String desc = event.getDescription();
 
     	HashMap<String, TileFlags> blkmaps = new HashMap<String, TileFlags>();
         LinkedList<TownBlock> nodevals = new LinkedList<TownBlock>();
@@ -804,12 +806,8 @@ public class DynmapTownyPlugin extends JavaPlugin {
                     m.setCornerLocations(x, z); /* Replace corner locations */
                     m.setLabel(name);   /* Update label */
                 }
-                {
-                    /* Set popup */
-                    BuildTownMarkerDescriptionEvent event = new BuildTownMarkerDescriptionEvent(town, desc);
-                    Bukkit.getPluginManager().callEvent(event);
-                    m.setDescription(event.getDescription());
-                }
+                /* Set popup */
+                m.setDescription(desc);
                 /* Set line and fill properties */
                 String nation = NATION_NONE;
                 try {
@@ -849,12 +847,9 @@ public class DynmapTownyPlugin extends JavaPlugin {
                         home.setLabel(name);   /* Update label */
                         home.setMarkerIcon(ico);
                     }
-                    {
-                        /* Set popup */
-                        BuildTownMarkerDescriptionEvent event = new BuildTownMarkerDescriptionEvent(town, desc);
-                        Bukkit.getPluginManager().callEvent(event);
-                        home.setDescription(event.getDescription());
-                    }
+                    /* Set popup */
+                    home.setDescription(desc);
+
                     newmark.put(markid, home);
                 }
             }

--- a/src/main/java/org/dynmap/towny/events/BuildTownMarkerDescriptionEvent.java
+++ b/src/main/java/org/dynmap/towny/events/BuildTownMarkerDescriptionEvent.java
@@ -1,0 +1,36 @@
+package org.dynmap.towny.events;
+
+import com.palmergames.bukkit.towny.object.Town;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+public class BuildTownMarkerDescriptionEvent extends Event {
+
+    private static final HandlerList handlers = new HandlerList();
+    private final Town town;
+    private String description;
+
+    public BuildTownMarkerDescriptionEvent(Town town, String description){
+       this.town = town;
+       this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @NotNull
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}


### PR DESCRIPTION
- With current code, it is difficult/impossible for other plugins to change the popup text for each town
- However this would be useful to multiple other plugins. 
- One example it that it would allow TownyCultures to display the culture on the town popup text.  This will go towards resolving the issue raised in  in #17 
- In this PR I resolve the issue by adding an event for building the description.  