### PR TITLE
Add a new `ruined` flag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.dynmap</groupId>
     <artifactId>Dynmap-Towny</artifactId>
-    <version>0.85</version>
+    <version>0.86</version>
 
     <build>
         <resources>

--- a/src/main/java/org/dynmap/towny/DynmapTownyPlugin.java
+++ b/src/main/java/org/dynmap/towny/DynmapTownyPlugin.java
@@ -52,6 +52,7 @@ import com.palmergames.bukkit.towny.exceptions.EconomyException;
 import com.palmergames.bukkit.towny.object.TownyWorld;
 import com.palmergames.bukkit.util.Version;
 import com.palmergames.bukkit.TownyChat.Chat;
+import org.dynmap.towny.events.BuildTownFlagsEvent;
 import org.dynmap.towny.events.BuildTownMarkerDescriptionEvent;
 
 public class DynmapTownyPlugin extends JavaPlugin {
@@ -515,18 +516,22 @@ public class DynmapTownyPlugin extends JavaPlugin {
         	v = v.replace("%upkeep%", TownyEconomyHandler.getFormattedBalance(TownySettings.getTownUpkeepCost(town)));
 
         /* Build flags */
-        String flags = "Has Upkeep: " + town.hasUpkeep();
-        flags += "<br/>pvp: " + town.isPVP();
-        flags += "<br/>mobs: " + town.hasMobs();
-        flags += "<br/>public: " + town.isPublic();
-        flags += "<br/>explosion: " + town.isBANG();
-        flags += "<br/>fire: " + town.isFire();
-        flags += "<br/>nation: " + nation;
+        List<String> flags = new ArrayList<>();
+        flags.add("Has Upkeep: " + town.hasUpkeep());
+        flags.add("pvp: " + town.isPVP());
+        flags.add("mobs: " + town.hasMobs());
+        flags.add("public: " + town.isPublic());
+        flags.add("explosion: " + town.isBANG());
+        flags.add("fire: " + town.isFire());
+        flags.add("nation: " + nation);
 
         if (TownySettings.getBoolean(ConfigNodes.TOWN_RUINING_TOWN_RUINS_ENABLED))
-            flags += "<br/>ruined: " + town.isRuined();
+            flags.add("ruined: " + town.isRuined());
 
-        v = v.replace("%flags%", flags);
+        BuildTownFlagsEvent buildTownFlagsEvent = new BuildTownFlagsEvent(town, flags);
+        Bukkit.getPluginManager().callEvent(buildTownFlagsEvent);
+
+        v = v.replace("%flags%", String.join("<br/>", buildTownFlagsEvent.getFlags()));
 
         return v;
     }

--- a/src/main/java/org/dynmap/towny/DynmapTownyPlugin.java
+++ b/src/main/java/org/dynmap/towny/DynmapTownyPlugin.java
@@ -13,6 +13,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.palmergames.bukkit.config.ConfigNodes;
 import com.palmergames.bukkit.towny.TownyEconomyHandler;
 import com.palmergames.bukkit.towny.TownyFormatter;
 import com.palmergames.bukkit.towny.TownySettings;
@@ -496,11 +497,9 @@ public class DynmapTownyPlugin extends JavaPlugin {
 	       	v = v.replace("%bank%", townBankBalanceCache.containsKey(town) ? TownyEconomyHandler.getFormattedBalance(townBankBalanceCache.get(town)) : "Accounts loading...");
         }
         String nation = "";
-		try {
-			if(town.hasNation())
-				nation = town.getNation().getName();
-		} catch (Exception e) {
-		}
+		if (town.hasNation())
+		    nation = TownyAPI.getInstance().getTownNationOrNull(town).getName();
+
         v = v.replace("%nation%", nation);
 
 		String natStatus = "";
@@ -516,14 +515,18 @@ public class DynmapTownyPlugin extends JavaPlugin {
         	v = v.replace("%upkeep%", TownyEconomyHandler.getFormattedBalance(TownySettings.getTownUpkeepCost(town)));
 
         /* Build flags */
-        String flgs = "Has Upkeep: " + town.hasUpkeep();
-        flgs += "<br/>pvp: " + town.isPVP();
-        flgs += "<br/>mobs: " + town.hasMobs();
-        flgs += "<br/>public: " + town.isPublic();
-        flgs += "<br/>explosion: " + town.isBANG();
-        flgs += "<br/>fire: " + town.isFire();
-        flgs += "<br/>nation: " + nation;
-        v = v.replace("%flags%", flgs);
+        String flags = "Has Upkeep: " + town.hasUpkeep();
+        flags += "<br/>pvp: " + town.isPVP();
+        flags += "<br/>mobs: " + town.hasMobs();
+        flags += "<br/>public: " + town.isPublic();
+        flags += "<br/>explosion: " + town.isBANG();
+        flags += "<br/>fire: " + town.isFire();
+        flags += "<br/>nation: " + nation;
+
+        if (TownySettings.getBoolean(ConfigNodes.TOWN_RUINING_TOWN_RUINS_ENABLED))
+            flags += "<br/>ruined: " + town.isRuined();
+
+        v = v.replace("%flags%", flags);
 
         return v;
     }

--- a/src/main/java/org/dynmap/towny/events/BuildTownFlagsEvent.java
+++ b/src/main/java/org/dynmap/towny/events/BuildTownFlagsEvent.java
@@ -1,0 +1,41 @@
+package org.dynmap.towny.events;
+
+import com.palmergames.bukkit.towny.object.Town;
+import org.bukkit.Bukkit;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+/**
+ * Called when
+ */
+public class BuildTownFlagsEvent extends Event {
+    private static HandlerList handlers = new HandlerList();
+    private final Town town;
+    private final List<String> flags;
+
+    public BuildTownFlagsEvent(Town town, List<String> flags) {
+        super(!Bukkit.getServer().isPrimaryThread());
+        this.town = town;
+        this.flags = flags;
+    }
+
+    public Town getTown() {
+        return town;
+    }
+
+    public List<String> getFlags() {
+        return flags;
+    }
+
+    @NotNull
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}


### PR DESCRIPTION
Adds a new ruined flag to the bottom of the flags section, if ruining is enabled in the towny config.

Closes https://github.com/TownyAdvanced/SiegeWar/issues/235