### PR TITLE
Added config option to enable/disable dynamic town colours

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.dynmap</groupId>
     <artifactId>Dynmap-Towny</artifactId>
-    <version>0.86</version>
+    <version>0.87</version>
 
     <build>
         <resources>

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -28,6 +28,8 @@ visibility-by-nation: true
 
 # Use dynamic nation colors, which are set in-game by individual nations (using /n set mapcolor <color>)
 dynamic-nation-colors: true
+# Use dynamic nation colors, which are set in-game by individual nations (using /t set mapcolor <color>)
+dynamic-town-colors: true
 
 # Format for popup - substitute values for macros
 infowindow: '<div class="infowindow"><span style="font-size:120%;">%regionname% (%nation%)</span><br /> Mayor <span style="font-weight:bold;">%playerowners%</span><br /> Associates <span style="font-weight:bold;">%playermanagers%</span><br/>Flags<br /><span style="font-weight:bold;">%flags%</span></div>'


### PR DESCRIPTION
**DESCRIPTION**
- Currently server admins are requesting a way to enable the dynamic-nation-colour feature without also enabling the dynamic-town-colours feature. 
- I looked into it but could not find a straightforward way.

**IMPLEMENTATION**
- Added new config option to enable/disable dynamic town colours.
- This can be combined in any combination with the existing switch for dynamic nation colours.
- Also updated the pom to the next version.

**TESTING**
- Tested all combinations of the 2 switches.