### PR TITLE
Enable Issues.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,15 +53,15 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.bukkit</groupId>
-            <artifactId>bukkit</artifactId>
-            <version>1.14.4-R0.1-SNAPSHOT</version>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>1.16.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>us.dynmap</groupId>
             <artifactId>dynmap-api</artifactId>
-            <version>2.5</version>
+            <version>3.1-beta-2</version>
         </dependency>
         <dependency>
             <groupId>com.github.TownyAdvanced</groupId>
@@ -71,9 +71,9 @@
         <dependency>
             <groupId>com.palmergames</groupId>
             <artifactId>TownyChat</artifactId>
-            <version>0.69</version>
+            <version>0.76</version>
             <scope>system</scope>
-            <systemPath>${project.basedir}/deps/TownyChat-0.69.jar</systemPath>
+            <systemPath>${project.basedir}/deps/TownyChat-0.76.jar</systemPath>
         </dependency>
     </dependencies>
     <properties>


### PR DESCRIPTION
I used a random fork to create this pull request, because I wanted to ask why Issues aren't enabled. Because they aren't enabled, PR's are the only way for the community to communicate with Dynmap-Towny.