### PR TITLE
Fix %residentdisplaynames% placeholder not using ", " in the list.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.dynmap</groupId>
     <artifactId>Dynmap-Towny</artifactId>
-    <version>0.90</version>
+    <version>0.91</version>
 
     <build>
         <resources>
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>com.palmergames.bukkit.towny</groupId>
             <artifactId>Towny</artifactId>
-            <version>0.98.1.0</version>
+            <version>0.98.4.0</version>
         </dependency>
         <dependency>
             <groupId>com.github.TownyAdvanced</groupId>

--- a/src/main/java/org/dynmap/towny/DynmapTownyPlugin.java
+++ b/src/main/java/org/dynmap/towny/DynmapTownyPlugin.java
@@ -57,7 +57,7 @@ import org.dynmap.towny.events.BuildTownMarkerDescriptionEvent;
 
 public class DynmapTownyPlugin extends JavaPlugin {
 	
-	private static Version requiredTownyVersion = Version.fromString("0.98.1.0");
+	private static Version requiredTownyVersion = Version.fromString("0.98.4.0");
     private static Logger log;
     private static final String DEF_INFOWINDOW = "<div class=\"infowindow\"><span style=\"font-size:120%;\">%regionname% (%nation%)</span><br /> Mayor <span style=\"font-weight:bold;\">%playerowners%</span><br /> Associates <span style=\"font-weight:bold;\">%playermanagers%</span><br/>Flags<br /><span style=\"font-weight:bold;\">%flags%</span></div>";
     private static final String NATION_NONE = "_none_";
@@ -466,17 +466,9 @@ public class DynmapTownyPlugin extends JavaPlugin {
 
         String dispNames = "";
         for (Resident r: town.getResidents()) {
-            Player p = Bukkit.getPlayer(r.getName());
-            if(dispNames.length()>0) mgrs += ", ";
-
-            if (p == null) {
-                dispNames += r.getFormattedName();
-                continue;
-            }
-
-            dispNames += p.getDisplayName();
+            if(dispNames.length()>0) dispNames += ", ";
+            dispNames += r.isOnline() ? r.getPlayer().getDisplayName() : r.getFormattedName();
         }
-
         v = v.replace("%residentdisplaynames%", dispNames);
 
         v = v.replace("%residentcount%", town.getResidents().size() + "");
@@ -521,7 +513,7 @@ public class DynmapTownyPlugin extends JavaPlugin {
         flags.add("Has Upkeep: " + town.hasUpkeep());
         flags.add("pvp: " + town.isPVP());
         flags.add("mobs: " + town.hasMobs());
-        flags.add("explosion: " + town.isBANG());
+        flags.add("explosion: " + town.isExplosion());
         flags.add("fire: " + town.isFire());
         flags.add("nation: " + nation);
 


### PR DESCRIPTION
Bump min. Towny version to 0.98.4.0.