### PR TITLE
Add TownSetMarkerIconEvent

### DIFF
--- a/src/main/java/org/dynmap/towny/DynmapTownyPlugin.java
+++ b/src/main/java/org/dynmap/towny/DynmapTownyPlugin.java
@@ -54,6 +54,7 @@ import com.palmergames.util.StringMgmt;
 import com.palmergames.bukkit.TownyChat.Chat;
 import org.dynmap.towny.events.BuildTownFlagsEvent;
 import org.dynmap.towny.events.BuildTownMarkerDescriptionEvent;
+import org.dynmap.towny.events.TownSetMarkerIconEvent;
 import org.dynmap.towny.events.TownRenderEvent;
 
 public class DynmapTownyPlugin extends JavaPlugin {
@@ -791,6 +792,12 @@ public class DynmapTownyPlugin extends JavaPlugin {
             if((blk != null) && isVisible(name, blk.getWorld().getName())) {
                 String markid = town.getName() + "__home";
                 MarkerIcon ico = getMarkerIcon(town);
+
+                /* Fire an event allowing other plugins to alter the MarkerIcon */
+                TownSetMarkerIconEvent iconEvent = new TownSetMarkerIconEvent(town, ico);
+                Bukkit.getPluginManager().callEvent(iconEvent);
+                ico = iconEvent.getIcon();
+
                 if(ico != null) {
                     Marker home = resmark.remove(markid);
                     double xx = townblocksize*blk.getX() + (townblocksize/2);

--- a/src/main/java/org/dynmap/towny/events/TownSetMarkerIconEvent.java
+++ b/src/main/java/org/dynmap/towny/events/TownSetMarkerIconEvent.java
@@ -1,0 +1,46 @@
+package org.dynmap.towny.events;
+
+import com.palmergames.bukkit.towny.object.Town;
+import org.bukkit.Bukkit;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.dynmap.markers.MarkerIcon;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Event called when the marker icon for a town is chosen.
+ */
+public class TownSetMarkerIconEvent extends Event {
+
+    private static final HandlerList handlers = new HandlerList();
+    private final Town town;
+    private MarkerIcon icon;
+
+    public TownSetMarkerIconEvent(Town town, MarkerIcon icon) {
+        super(!Bukkit.getServer().isPrimaryThread());
+        this.town = town;
+        this.icon = icon;
+    }
+
+    public Town getTown() {
+        return town;
+    }
+
+    public void setIcon(MarkerIcon icon) {
+        this.icon = icon;
+    }
+
+    public MarkerIcon getIcon() {
+        return icon;
+    }
+
+    @NotNull
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}


### PR DESCRIPTION
This PR adds `TownSetMarkerIconEvent`, an event which allows plugins to retrieve and modify the `MarkerIcon` that will be selected for a town. This event has been successfully tested locally. Inspired by a [player suggestion](https://ccnetmc.com/suggestions/view/1568-add-new-town-categories-and-dynmap-emblems/).