### PR TITLE
Change outpost to use formatted description

### DIFF
--- a/src/main/java/org/dynmap/towny/mapupdate/UpdateTowns.java
+++ b/src/main/java/org/dynmap/towny/mapupdate/UpdateTowns.java
@@ -444,7 +444,7 @@ public class UpdateTowns implements Runnable {
 		}
 
 		if (town.hasOutpostSpawn())
-			drawOutpostIcons(town, newWorldNameMarkerMap);
+			drawOutpostIcons(town, newWorldNameMarkerMap, desc);
 	}
 
 	private MarkerIcon getMarkerIcon(Town town) {
@@ -481,7 +481,7 @@ public class UpdateTowns implements Runnable {
 		newWorldNameMarkerMap.put(markid, home);
 	}
 
-	private void drawOutpostIcons(Town town, Map<String, Marker> newWorldNameMarkerMap) {
+	private void drawOutpostIcons(Town town, Map<String, Marker> newWorldNameMarkerMap, String desc) {
 		MarkerIcon outpostIco = Settings.getOutpostIcon();
 		int i = 0;
 		for (Location loc : town.getAllOutpostSpawns()) {
@@ -504,7 +504,7 @@ public class UpdateTowns implements Runnable {
 				outpostMarker.setLabel(outpostName);
 				outpostMarker.setMarkerIcon(outpostIco);
 			}
-			outpostMarker.setDescription(townBlock.getName() != null ? townBlock.getName() : outpostName);
+			outpostMarker.setDescription(desc);
 			newWorldNameMarkerMap.put(outpostMarkerID, outpostMarker);
 		}
 	}


### PR DESCRIPTION
Changes outpost icon description to the formatted town tooltip

Current outpost icons generally give no response when clicked as the description is generally the same as the name, giving  identical output. 

Clicked towns, borders and claims all open the tooltip so it seems better for it to also do this - additionally prevents the icon preventing you from viewing this by taking over the whole claim on some zooms with smaller claims.

Technically does mean the plot name can not be displayed but I don't think this is particularly useful anyway.